### PR TITLE
Urls with dots in the query string keys are not correctly parsed

### DIFF
--- a/src/Components/Query.php
+++ b/src/Components/Query.php
@@ -106,7 +106,13 @@ class Query extends AbstractComponentArray implements ComponentArray, ArrayAcces
             if ('?' == $str[0]) {
                 $str = substr($str, 1);
             }
+            
+            // from: https://stackoverflow.com/a/22539704
+            $str = preg_replace_callback('/(?:^|(?<=&))[^=[]+/', function($match) {
+                return bin2hex(urldecode($match[0]));
+            }, $str);
             parse_str($str, $arr);
+            $arr = array_combine(array_map('hex2bin', array_keys($arr)), $arr);
 
             return $arr;
         });

--- a/tests/Components/QueryTest.php
+++ b/tests/Components/QueryTest.php
@@ -123,4 +123,16 @@ class QueryTest extends PHPUnit_Framework_TestCase
         $this->assertSame(array('lol'), $query->keys(3));
         $this->assertSame(array('baz', 'toto'), $query->keys('troll'));
     }
+
+    public function testDotFromString()
+    {
+        $query = new Query('foo.bar=baz');
+        $this->assertSame('foo.bar=baz', (string) $query);
+    }
+
+    public function testDotFromArray()
+    {
+        $query = new Query(array('foo.bar' => 'baz'));
+        $this->assertSame('foo.bar=baz', (string) $query);
+    }
 }


### PR DESCRIPTION
Because parse_str() allows to create variables from strings, PHP automaticly replaces dots with underscores. This is a problem if you have to parse query strings like "?foo.bar=baz".
I hope the pull request targets the correct branch, I'm quite new to this.
