### PR TITLE
Altered return hinting

### DIFF
--- a/src/AbstractUrl.php
+++ b/src/AbstractUrl.php
@@ -169,7 +169,7 @@ abstract class AbstractUrl implements UrlInterface
      *
      * @param string $url a string or an object that implement the __toString method
      *
-     * @return AbstractUrl
+     * @return static
      *
      * @throws RuntimeException If the URL can not be parse
      */
@@ -218,7 +218,7 @@ abstract class AbstractUrl implements UrlInterface
      *
      * @param array $server the server array
      *
-     * @return AbstractUrl
+     * @return static
      *
      * @throws RuntimeException If the URL can not be parse
      */


### PR DESCRIPTION
Since this method can be invoked form a child class, the return type of "AbstractUrl" does not allow the IDE to provide proper autocomplete of the Url or UrlImmutable classes.

By returning `static` IDEs can figure this out from the invoke context, as well as it indicating that this class can be invoked form children.
