### PR TITLE
Alias develop-4 to 4.0.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev"
+            "dev-develop-4": "4.0-dev"
         }
     }
 }


### PR DESCRIPTION
That way people can ask for `4.0.*` and get the dev version without using branches as version constraints which is a bad practice.
