### PR TITLE
Let return all set method $this to allow a fluent use of the interface

### DIFF
--- a/src/AbstractComponent.php
+++ b/src/AbstractComponent.php
@@ -51,6 +51,8 @@ abstract class AbstractComponent
         }
         $data = filter_var((string) $data, FILTER_UNSAFE_RAW, ['flags' => FILTER_FLAG_STRIP_LOW]);
         $this->data = trim($data);
+				
+				return $this;
     }
 
     /**

--- a/src/AbstractSegment.php
+++ b/src/AbstractSegment.php
@@ -47,6 +47,8 @@ abstract class AbstractSegment extends AbstractContainer
         $this->data = array_filter($this->validate($data), function ($value) {
             return ! is_null($value);
         });
+				
+				return $this;
     }
 
     /**
@@ -144,6 +146,8 @@ abstract class AbstractSegment extends AbstractContainer
      * @param string|array|\Traversable $data
      * @param string                    $whence
      * @param integer                   $whence_index
+		 * 
+		 * @return static $this for chaining
      */
     public function append($data, $whence = null, $whence_index = null)
     {
@@ -153,6 +157,8 @@ abstract class AbstractSegment extends AbstractContainer
             $whence,
             $whence_index
         );
+				
+				return $this;
     }
 
     /**
@@ -160,6 +166,8 @@ abstract class AbstractSegment extends AbstractContainer
      * @param string|array|\Traversable $data
      * @param string                    $whence
      * @param integer                   $whence_index
+		 * 
+		 * @return static $this for chaining
      */
     public function prepend($data, $whence = null, $whence_index = null)
     {
@@ -169,6 +177,8 @@ abstract class AbstractSegment extends AbstractContainer
             $whence,
             $whence_index
         );
+				
+				return $this;
     }
 
     /**

--- a/src/Host.php
+++ b/src/Host.php
@@ -96,6 +96,8 @@ class Host extends AbstractSegment implements
         $this->data = array_filter($this->validate($data), function ($value) {
             return ! is_null($value);
         });
+				
+				return $this;
     }
 
     /**

--- a/src/Interfaces/ComponentInterface.php
+++ b/src/Interfaces/ComponentInterface.php
@@ -25,7 +25,7 @@ interface ComponentInterface
      *
      * @param mixed $data data to be added
      *
-     * @return void
+     * @return static $this for chaining
      */
     public function set($data);
 

--- a/src/Interfaces/QueryInterface.php
+++ b/src/Interfaces/QueryInterface.php
@@ -38,6 +38,8 @@ interface QueryInterface extends ComponentInterface
      * Query Parameter setter using an array
      *
      * @param array $data
+		 * 
+		 * @return static $this for chaining
      */
     public function modify($data);
 
@@ -56,6 +58,8 @@ interface QueryInterface extends ComponentInterface
      *
      * @param string $key   the query parameter key
      * @param mixed  $value the query parameter value
+		 * 
+		 * @return static $this for chaining
      */
     public function setParameter($key, $value);
 }

--- a/src/Port.php
+++ b/src/Port.php
@@ -42,6 +42,8 @@ class Port extends AbstractComponent implements ComponentInterface
         }
 
         $this->data = (int) $data;
+				
+				return $this;
     }
 
     /**

--- a/src/Query.php
+++ b/src/Query.php
@@ -53,6 +53,8 @@ class Query extends AbstractContainer implements
 
             return null !== $value && '' !== $value;
         });
+				
+				return $this;
     }
 
     /**
@@ -94,6 +96,8 @@ class Query extends AbstractContainer implements
     public function modify($data)
     {
         $this->set(array_merge($this->data, $this->validate($data)));
+				
+				return $this;
     }
 
     /**
@@ -143,6 +147,7 @@ class Query extends AbstractContainer implements
      *
      * @param string $key   the query parameter key
      * @param mixed  $value the query parameter value
+		 * @return static $this for chaining
      */
     public function setParameter($key, $value)
     {
@@ -150,6 +155,8 @@ class Query extends AbstractContainer implements
             throw new RuntimeException('offset can not be null');
         }
         $this->modify([$key => $value]);
+				
+				return $this;
     }
 
     /**

--- a/src/Scheme.php
+++ b/src/Scheme.php
@@ -41,6 +41,8 @@ class Scheme extends AbstractComponent implements ComponentInterface
         }
 
         $this->data = strtolower($data);
+				
+				return $this;
     }
 
     /**


### PR DESCRIPTION
Hi Ignace,

I would like you to consider my PR to implement a fluent interface for all setter methods.
I changed it mainly to later query parts.

With the current version, you always have to store the query-object to alter it:

``` php
$url = \League\Url\UrlImmutable::createFromServer($_SERVER);
$query = $url->getQuery();
$query->set(['page' => 123]);
$newurl = $url->setQuery($query);
```

The fluent interface would allow to alter the query string in a single line:

``` php
$url = \League\Url\UrlImmutable::createFromServer($_SERVER);
$newurl = $url->setQuery($url->getQuery()->set(['page' => $page]));
```

Thanks for considering!
Greets,
Dennis
