### PR TITLE
Improve code base readability

### DIFF
--- a/src/AbstractComponent.php
+++ b/src/AbstractComponent.php
@@ -49,8 +49,14 @@ abstract class AbstractComponent
 
             return;
         }
-        $data = filter_var((string) $data, FILTER_UNSAFE_RAW, ['flags' => FILTER_FLAG_STRIP_LOW]);
-        $this->data = trim($data);
+
+        $this->data = trim(
+            filter_var(
+                (string) $data,
+                FILTER_UNSAFE_RAW,
+                ['flags' => FILTER_FLAG_STRIP_LOW]
+            )
+        );
     }
 
     /**
@@ -78,6 +84,6 @@ abstract class AbstractComponent
      */
     public function sameValueAs(ComponentInterface $component)
     {
-        return $this->__toString() == $component->__toString();
+        return $this->__toString() === $component->__toString();
     }
 }

--- a/src/AbstractContainer.php
+++ b/src/AbstractContainer.php
@@ -51,6 +51,7 @@ abstract class AbstractContainer
     public function keys()
     {
         $args = func_get_args();
+
         if (! $args) {
             return array_keys($this->data);
         }
@@ -109,9 +110,13 @@ abstract class AbstractContainer
     {
         if (is_null($data)) {
             return [];
-        } elseif ($data instanceof Traversable) {
+        }
+
+        if ($data instanceof Traversable) {
             return iterator_to_array($data);
-        } elseif (self::isStringable($data)) {
+        }
+
+        if (self::isStringable($data)) {
             $data = (string) $data;
             $data = trim($data);
             $data = $callback($data);

--- a/src/AbstractSegment.php
+++ b/src/AbstractSegment.php
@@ -55,11 +55,13 @@ abstract class AbstractSegment extends AbstractContainer
     public function remove($data)
     {
         $data = $this->fetchRemainingSegment($this->data, $data);
+
         if (! is_null($data)) {
             $this->set($data);
 
             return true;
         }
+
         return false;
     }
 
@@ -76,15 +78,19 @@ abstract class AbstractSegment extends AbstractContainer
             foreach ($str as &$value) {
                 $value = $this->sanitizeValue($value);
             }
+
             unset($value);
 
             return $str;
         }
 
-        $str = filter_var((string) $str, FILTER_UNSAFE_RAW, ['flags' => FILTER_FLAG_STRIP_LOW]);
-        $str = trim($str);
-
-        return $str;
+        return trim(
+            filter_var(
+                (string) $str,
+                FILTER_UNSAFE_RAW,
+                ['flags' => FILTER_FLAG_STRIP_LOW]
+            )
+        );
     }
 
     /**
@@ -154,10 +160,11 @@ abstract class AbstractSegment extends AbstractContainer
     protected function validateSegment($data)
     {
         return $this->convertToArray($data, function ($str) {
-            if ('' == $str) {
+            if ('' === $str) {
                 return [];
             }
-            if ($this->delimiter == $str[0]) {
+
+            if ($this->delimiter === $str[0]) {
                 $str = substr($str, 1);
             }
 
@@ -178,12 +185,15 @@ abstract class AbstractSegment extends AbstractContainer
     protected function appendSegment(array $left, array $value, $whence = null, $whence_index = null)
     {
         $right = [];
-        if (null !== $whence && count($found = array_keys($left, $whence))) {
+
+        if (! is_null($whence) && count($found = array_keys($left, $whence))) {
             array_reverse($found);
             $index = $found[0];
+
             if (array_key_exists($whence_index, $found)) {
                 $index = $found[$whence_index];
             }
+
             $right = array_slice($left, $index+1);
             $left = array_slice($left, 0, $index+1);
         }
@@ -204,11 +214,14 @@ abstract class AbstractSegment extends AbstractContainer
     protected function prependSegment(array $right, array $value, $whence = null, $whence_index = null)
     {
         $left = [];
+
         if (null !== $whence && count($found = array_keys($right, $whence))) {
             $index = $found[0];
+
             if (array_key_exists($whence_index, $found)) {
                 $index = $found[$whence_index];
             }
+
             $left = array_slice($right, 0, $index);
             $right = array_slice($right, $index);
         }
@@ -229,7 +242,8 @@ abstract class AbstractSegment extends AbstractContainer
     protected function fetchRemainingSegment(array $data, $value)
     {
         $segment = implode($this->delimiter, $data);
-        if ('' == $value) {
+
+        if ('' === $value) {
             if ($index = array_search('', $data, true)) {
                 $left = array_slice($data, 0, $index);
                 $right = array_slice($data, $index+1);

--- a/src/Fragment.php
+++ b/src/Fragment.php
@@ -36,6 +36,7 @@ class Fragment extends AbstractComponent implements ComponentInterface
     public function __toString()
     {
         $value = str_replace(null, '', $this->get());
+
         $encodedSymbols = array_map(function ($symbol) {
             return urlencode($symbol);
         }, $this->rawSymbols);
@@ -53,7 +54,8 @@ class Fragment extends AbstractComponent implements ComponentInterface
     public function getUriComponent()
     {
         $value = $this->__toString();
-        if ('' != $value) {
+
+        if ('' !== $value) {
             $value = '#'.$value;
         }
 

--- a/src/Host.php
+++ b/src/Host.php
@@ -60,6 +60,7 @@ class Host extends AbstractSegment implements
     protected function saveInternalEncoding()
     {
         $this->encoding = mb_internal_encoding();
+
         if (stripos($this->encoding, 'utf-8') === false) {
             mb_internal_encoding('utf-8');
         }
@@ -75,6 +76,7 @@ class Host extends AbstractSegment implements
     protected function sanitizeValue($str)
     {
         $str = parent::sanitizeValue($str);
+
         if (is_array($str)) {
             return array_map('mb_strtolower', $str);
         }
@@ -107,6 +109,7 @@ class Host extends AbstractSegment implements
     public function set($data)
     {
         $this->setHostAsIp($data);
+
         if ($this->isIp()) {
             return;
         }
@@ -122,9 +125,11 @@ class Host extends AbstractSegment implements
     public function get()
     {
         $res = [];
+
         foreach (array_values($this->data) as $value) {
             $res[] = $this->punycode->decode($value);
         }
+
         if (! $res) {
             return null;
         }
@@ -165,7 +170,7 @@ class Host extends AbstractSegment implements
             return mb_strlen($label) > 63;
         });
 
-        return 0 == count($res);
+        return 0 === count($res);
     }
 
     /**
@@ -184,12 +189,12 @@ class Host extends AbstractSegment implements
 
         $res = preg_grep('/^[0-9a-z]([0-9a-z-]{0,61}[0-9a-z])?$/i', $data, PREG_GREP_INVERT);
 
-        return 0 == count($res);
+        return 0 === count($res);
     }
 
     protected function isValidHostLabels(array $data = [])
     {
-        $labels       = array_merge($this->data, $data);
+        $labels = array_merge($this->data, $data);
         $count_labels = count($labels);
 
         return $count_labels > 0 && $count_labels < 127 && 255 > strlen(implode($this->delimiter, $labels));
@@ -207,18 +212,24 @@ class Host extends AbstractSegment implements
     protected function validate($data)
     {
         $data = $this->validateSegment($data);
+
         if (! $data) {
             return $data;
         }
 
         $this->saveInternalEncoding();
+
         if (! $this->isValidHostLength($data)) {
             $this->restoreInternalEncoding();
             throw new RuntimeException('Invalid hostname, check its length');
-        } elseif (! $this->isValidHostPattern($data)) {
+        }
+
+        if (! $this->isValidHostPattern($data)) {
             $this->restoreInternalEncoding();
             throw new RuntimeException('Invalid host label, check its content');
-        } elseif (! $this->isValidHostLabels($data)) {
+        }
+
+        if (! $this->isValidHostLabels($data)) {
             $this->restoreInternalEncoding();
             throw new RuntimeException('Invalid host label counts, check its count');
         }
@@ -228,6 +239,7 @@ class Host extends AbstractSegment implements
             $this->delimiter,
             $this->punycode->decode(implode($this->delimiter, $data))
         );
+
         $this->restoreInternalEncoding();
 
         return $data;
@@ -266,17 +278,21 @@ class Host extends AbstractSegment implements
     {
         $this->host_as_ipv4 = false;
         $this->host_as_ipv6 = false;
+
         if (! self::isStringable($str)) {
             return;
         }
 
         $str = (string) $str;
+
         $str = trim($str);
         if ('[' == $str[0] && ']' == $str[strlen($str)-1]) {
             $str = substr($str, 1, -1);
+
             if (! filter_var($str, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
                 return false;
             }
+
             $this->host_as_ipv4 = false;
             $this->host_as_ipv6 = true;
             $this->data = [$str];
@@ -287,7 +303,9 @@ class Host extends AbstractSegment implements
             $this->host_as_ipv4 = true;
             $this->host_as_ipv6 = false;
             $this->data = [$str];
-        } elseif (filter_var($str, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
+        }
+
+        if (filter_var($str, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
             $this->host_as_ipv4 = false;
             $this->host_as_ipv6 = true;
             $this->data = [$str];
@@ -332,6 +350,7 @@ class Host extends AbstractSegment implements
     public function getUriComponent()
     {
         $str = $this->__toString();
+
         if ($this->host_as_ipv6) {
             return '['.$str.']';
         }
@@ -353,6 +372,7 @@ class Host extends AbstractSegment implements
     public function getLabel($offset, $default = null)
     {
         $offset = filter_var($offset, FILTER_VALIDATE_INT, ['options' => ["min_range" => 0]]);
+
         if (false === $offset || ! isset($this->data[$offset])) {
             return $default;
         }
@@ -369,13 +389,13 @@ class Host extends AbstractSegment implements
             "min_range" => 0,
             "max_range" => $this->count(),
         ]]);
+
         if (false === $offset) {
             throw new OutOfBoundsException('The specified key is not in the object boundaries');
         }
 
         $data = $this->data;
-        $value = filter_var((string) $value, FILTER_UNSAFE_RAW, ['flags' => FILTER_FLAG_STRIP_LOW]);
-        $value = trim($value);
+        $value = trim(filter_var((string) $value, FILTER_UNSAFE_RAW, ['flags' => FILTER_FLAG_STRIP_LOW]));
 
         if (empty($value)) {
             unset($data[$offset]);
@@ -383,7 +403,8 @@ class Host extends AbstractSegment implements
         }
 
         $data[$offset] = $value;
-        if (1 == count($data)) {
+
+        if (1 === count($data)) {
             return $this->set($value);
         }
 

--- a/src/Pass.php
+++ b/src/Pass.php
@@ -28,7 +28,8 @@ class Pass extends AbstractComponent implements ComponentInterface
     public function getUriComponent()
     {
         $value = $this->__toString();
-        if ('' != $value) {
+
+        if ('' !== $value) {
             $value = ':'.$value;
         }
 

--- a/src/Path.php
+++ b/src/Path.php
@@ -50,9 +50,11 @@ class Path extends AbstractSegment implements
     public function get()
     {
         $res = [];
+
         foreach (array_values($this->data) as $value) {
             $res[] = rawurlencode($value);
         }
+
         if (! $res) {
             return null;
         }
@@ -86,6 +88,7 @@ class Path extends AbstractSegment implements
     public function normalize()
     {
         $path = $this->getUriComponent();
+
         if (false === strpos($path, '.')) {
             return new static($path);
         }
@@ -93,25 +96,35 @@ class Path extends AbstractSegment implements
         $input  = $path;
         $output = [];
 
-        while ('' != $input) {
+        while ('' !== $input) {
             if ('/.' == $input) {
                 $output[] = '/';
                 break;
-            } elseif ('/./' == substr($input, 0, 3)) {
+            }
+
+            if ('/./' == substr($input, 0, 3)) {
                 $input = substr($input, 2);
                 continue;
-            } elseif ('/..' == $input) {
+            }
+
+            if ('/..' == $input) {
                 array_pop($output);
                 $output[] = '/';
                 break;
-            } elseif ('/../' == substr($input, 0, 4)) {
-                array_pop($output);
-                $input = substr($input, 3);
-            } elseif (in_array($input, ['.', '..'])) {
+            }
+
+            if (in_array($input, ['.', '..'])) {
                 break;
-            } elseif (false === ($pos = stripos($input, '/', 1))) {
+            }
+
+            if (false === ($pos = stripos($input, '/', 1))) {
                 $output[] = $input;
                 break;
+            }
+
+            if ('/../' == substr($input, 0, 4)) {
+                array_pop($output);
+                $input = substr($input, 3);
             } else {
                 $output[] = substr($input, 0, $pos);
                 $input = substr($input, $pos);
@@ -142,6 +155,7 @@ class Path extends AbstractSegment implements
     protected function sanitizeValue($str)
     {
         $str = parent::sanitizeValue($str);
+
         if (is_array($str)) {
             return array_map([$this, 'sanitizeSegment'], $str);
         }
@@ -172,6 +186,7 @@ class Path extends AbstractSegment implements
     public function getSegment($offset, $default = null)
     {
         $offset = filter_var($offset, FILTER_VALIDATE_INT, ['options' => ["min_range" => 0]]);
+
         if (false === $offset || ! isset($this->data[$offset])) {
             return $default;
         }
@@ -188,6 +203,7 @@ class Path extends AbstractSegment implements
             "min_range" => 0,
             "max_range" => $this->count(),
         ]]);
+
         if (false === $offset) {
             throw new OutOfBoundsException('The specified key is not in the object boundaries');
         }

--- a/src/Port.php
+++ b/src/Port.php
@@ -34,8 +34,7 @@ class Port extends AbstractComponent implements ComponentInterface
         }
 
         $data = (string) $data;
-        $data = trim($data);
-        $data = filter_var($data, FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+        $data = filter_var(trim($data), FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
 
         if (! $data) {
             throw new RuntimeException('A port must be a valid positive integer');
@@ -50,7 +49,8 @@ class Port extends AbstractComponent implements ComponentInterface
     public function getUriComponent()
     {
         $value = $this->__toString();
-        if ('' != $value) {
+
+        if ('' !== $value) {
             $value = ':'.$value;
         }
 

--- a/src/Query.php
+++ b/src/Query.php
@@ -81,6 +81,7 @@ class Query extends AbstractContainer implements
     public function getUriComponent()
     {
         $value = $this->__toString();
+
         if ('' != $value) {
             $value = '?'.$value;
         }
@@ -105,6 +106,7 @@ class Query extends AbstractContainer implements
             if ('' == $str) {
                 return [];
             }
+
             if ('?' == $str[0]) {
                 $str = substr($str, 1);
             }
@@ -113,6 +115,7 @@ class Query extends AbstractContainer implements
             $str = preg_replace_callback('/(?:^|(?<=&))[^=[]+/', function ($match) {
                 return bin2hex(urldecode($match[0]));
             }, $str);
+
             parse_str($str, $arr);
 
             return array_combine(array_map('hex2bin', array_keys($arr)), $arr);
@@ -131,6 +134,7 @@ class Query extends AbstractContainer implements
     public function getParameter($key, $default = null)
     {
         $res = $this->offsetGet($key);
+
         if (is_null($res)) {
             return $default;
         }
@@ -149,6 +153,7 @@ class Query extends AbstractContainer implements
         if (is_null($key)) {
             throw new RuntimeException('offset can not be null');
         }
+
         $this->modify([$key => $value]);
     }
 

--- a/src/Scheme.php
+++ b/src/Scheme.php
@@ -33,9 +33,9 @@ class Scheme extends AbstractComponent implements ComponentInterface
             return;
         }
 
-        $data = filter_var((string) $data, FILTER_UNSAFE_RAW, ['flags' => FILTER_FLAG_STRIP_LOW]);
-        $data = trim($data);
+        $data = trim(filter_var((string) $data, FILTER_UNSAFE_RAW, ['flags' => FILTER_FLAG_STRIP_LOW]));
         $data = filter_var($data, FILTER_VALIDATE_REGEXP, ['options' => ['regexp' => '/^[a-z][a-z0-9+-.]+$/i']]);
+
         if (! $data) {
             throw new RuntimeException('This class only deals with http URL');
         }
@@ -49,7 +49,8 @@ class Scheme extends AbstractComponent implements ComponentInterface
     public function getUriComponent()
     {
         $value = $this->__toString();
-        if ('' != $value) {
+
+        if ('' !== $value) {
             $value .= '://';
         }
 

--- a/src/Traits/Factory.php
+++ b/src/Traits/Factory.php
@@ -42,7 +42,9 @@ trait Factory
         if (is_null($url)) {
             throw new RuntimeException(sprintf('The given URL: `%s` could not be parse', $original_url));
         }
+
         $components = @parse_url($url);
+
         if (false === $components) {
             throw new RuntimeException(sprintf('The given URL: `%s` could not be parse', $original_url));
         }
@@ -54,11 +56,14 @@ trait Factory
     {
         if ('' == $url || strpos($url, '//') === 0) {
             return $url;
-        } elseif (! preg_match(',^((http|ftp|ws)s?:),i', $url, $matches)) {
+        }
+
+        if (! preg_match(',^((http|ftp|ws)s?:),i', $url, $matches)) {
             return '//'.$url;
         }
 
         $scheme_length = strlen($matches[0]);
+
         if (strpos(substr($url, $scheme_length), '//') === 0) {
             return $url;
         }
@@ -77,12 +82,10 @@ trait Factory
      */
     public static function createFromServer(array $server)
     {
-        $scheme = self::fetchServerScheme($server);
-        $host = self::fetchServerHost($server);
-        $port = self::fetchServerPort($server);
-        $request = self::fetchServerRequestUri($server);
-
-        return self::createFromUrl($scheme.$host.$port.$request);
+        return self::createFromUrl(
+            self::fetchServerScheme($server).self::fetchServerHost($server).self::fetchServerPort($server).
+            self::fetchServerRequestUri($server)
+        );
     }
 
     /**
@@ -95,12 +98,15 @@ trait Factory
     private static function fetchServerScheme(array $server)
     {
         $scheme = '';
+
         if (isset($server['SERVER_PROTOCOL'])) {
             $scheme = explode('/', $server['SERVER_PROTOCOL']);
             $scheme = strtolower($scheme[0]);
+
             if (isset($server['HTTPS']) && 'off' != $server['HTTPS']) {
                 $scheme .= 's';
             }
+
             $scheme .= ':';
         }
 
@@ -120,11 +126,15 @@ trait Factory
     {
         if (isset($server['HTTP_HOST'])) {
             $header = $server['HTTP_HOST'];
+
             if (! preg_match('/(:\d+)$/', $header, $matches)) {
                 return $header;
             }
+
             return substr($header, 0, -strlen($matches[1]));
-        } elseif (isset($server['SERVER_ADDR'])) {
+        }
+
+        if (isset($server['SERVER_ADDR'])) {
             return $server['SERVER_ADDR'];
         }
 
@@ -141,7 +151,8 @@ trait Factory
     private static function fetchServerPort(array $server)
     {
         $port = '';
-        if (isset($server['SERVER_PORT']) && '80' != $server['SERVER_PORT']) {
+
+        if (isset($server['SERVER_PORT']) && '80' !== $server['SERVER_PORT']) {
             $port = ':'. (int) $server['SERVER_PORT'];
         }
 
@@ -159,7 +170,9 @@ trait Factory
     {
         if (isset($server['REQUEST_URI'])) {
             return $server['REQUEST_URI'];
-        } elseif (isset($server['PHP_SELF'])) {
+        }
+
+        if (isset($server['PHP_SELF'])) {
             return $server['PHP_SELF'];
         }
 

--- a/src/Url.php
+++ b/src/Url.php
@@ -134,11 +134,8 @@ final class Url implements UrlInterface
             .$this->path->getUriComponent()
             .$this->query->getUriComponent()
             .$this->fragment->getUriComponent();
-        if ('/' == $url) {
-            return '';
-        }
 
-        return $url;
+        return $url === '/' ? '' : $url;
     }
 
     /**
@@ -166,6 +163,7 @@ final class Url implements UrlInterface
     public function getUserInfo()
     {
         $user = $this->user->getUriComponent().$this->pass->getUriComponent();
+
         if ('' != $user) {
             $user .= '@';
         }
@@ -178,11 +176,7 @@ final class Url implements UrlInterface
      */
     public function getAuthority()
     {
-        $user = $this->getUserInfo();
-        $host = $this->host->getUriComponent();
-        $port = $this->port->getUriComponent();
-
-        return $user.$host.$port;
+        return $this->getUserInfo().$this->host->getUriComponent().$this->port->getUriComponent();
     }
 
     /**
@@ -192,7 +186,8 @@ final class Url implements UrlInterface
     {
         $scheme = $this->scheme->getUriComponent();
         $auth = $this->getAuthority();
-        if ('' != $auth && '' == $scheme) {
+
+        if ('' !== $auth && '' === $scheme) {
             $scheme = '//';
         }
 

--- a/tests/HostTest.php
+++ b/tests/HostTest.php
@@ -11,7 +11,6 @@ use PHPUnit_Framework_TestCase;
  */
 class HostTest extends PHPUnit_Framework_TestCase
 {
-
     public function testIpv4()
     {
         $host = new Host('127.0.0.1');

--- a/tests/UrlTest.php
+++ b/tests/UrlTest.php
@@ -62,6 +62,7 @@ class UrlTest extends PHPUnit_Framework_TestCase
             'SERVER_PORT' => 23,
             'HTTP_HOST' => 'example.com',
         ];
+
         $url = Url::createFromServer($server);
         $this->assertInstanceof('\League\Url\Url', $url);
         $this->assertSame('https://example.com:23/', $url->__toString());
@@ -91,6 +92,7 @@ class UrlTest extends PHPUnit_Framework_TestCase
             'SERVER_PORT' => 23,
             'HTTP_HOST' => 'localhost:23',
         ];
+
         $url = Url::createFromServer($server);
         $this->assertInstanceof('\League\Url\Url', $url);
         $this->assertSame('https://localhost:23/', $url->__toString());
@@ -121,6 +123,7 @@ class UrlTest extends PHPUnit_Framework_TestCase
             'SERVER_PROTOCOL' => 'HTTP',
             'SERVER_PORT' => 23,
         ];
+
         $url = Url::createFromServer($server);
         $this->assertSame('https://127.0.0.1:23/toto?foo=bar', (string) $url);
 
@@ -130,6 +133,7 @@ class UrlTest extends PHPUnit_Framework_TestCase
             'SERVER_PROTOCOL' => 'HTTP',
             'SERVER_PORT' => 23,
         ];
+
         $url = Url::createFromServer($server);
 
         $this->assertSame('https://127.0.0.1:23/', (string) $url);
@@ -145,10 +149,12 @@ class UrlTest extends PHPUnit_Framework_TestCase
             '//login@example.com/',
             (string) Url::createFromUrl('login@example.com/')
         );
+
         $this->assertSame(
             '//login:pass@example.com/',
             (string) Url::createFromUrl('login:pass@example.com/')
         );
+
         $this->assertSame(
             'http://login:pass@example.com/',
             (string) Url::createFromUrl('http://login:pass@example.com/')
@@ -195,6 +201,7 @@ class UrlTest extends PHPUnit_Framework_TestCase
         $url = Url::createFromUrl(
             'https://login:pass@secure.example.com:443/test/query.php?kingkong=toto#doc3'
         );
+
         $this->assertSame('https://login:pass@secure.example.com:443', $url->getBaseUrl());
         $this->assertSame('login:pass@secure.example.com:443', $url->getAuthority());
         $this->assertSame('login:pass@', $url->getUserInfo());
@@ -205,6 +212,7 @@ class UrlTest extends PHPUnit_Framework_TestCase
         $url = Url::createFromUrl(
             'HtTpS://MaStEr.eXaMpLe.CoM:80/%7ejohndoe/%a1/index.php?foo.bar=value#fragment'
         );
+
         $this->assertSame(
             'https://master.example.com:80/~johndoe/%A1/index.php?foo.bar=value#fragment',
             (string) $url
@@ -214,6 +222,7 @@ class UrlTest extends PHPUnit_Framework_TestCase
     public function testToArray()
     {
         $url = Url::createFromUrl('https://toto.com:443/toto.php');
+
         $this->assertSame([
             'scheme' => 'https',
             'user' => null,


### PR DESCRIPTION
### Changes contain
- Improve consistency of vertical spacing
- Minimize `else` and `elseif` conditionals 
- Remove variables created just for `return` statements
- Use `===` instead of `==`

### Test cases affected
- None