### PR TITLE
Fix: Url should be Url\Url

### DIFF
--- a/src/Utilities/UrlModifier.php
+++ b/src/Utilities/UrlModifier.php
@@ -212,9 +212,9 @@ trait UrlModifier
     /**
      * Convert to an Url object
      *
-     * @param  Url|string $url
+     * @param  Url\Url|string $url
      *
-     * @return Url
+     * @return Url\Url
      */
     protected function convertToUrlObject($url)
     {


### PR DESCRIPTION
This PR

* [x] fixes a docblock which refers to an undefined class