### PR TITLE
Fix: Spelling in comments

### DIFF
--- a/src/AbstractCollectionComponent.php
+++ b/src/AbstractCollectionComponent.php
@@ -41,7 +41,7 @@ abstract class AbstractCollectionComponent
     }
 
     /**
-     * Initiliaze the object data
+     * Initialize the object data
      *
      * @param string $str the raw component string
      */

--- a/src/AbstractComponent.php
+++ b/src/AbstractComponent.php
@@ -60,7 +60,7 @@ abstract class AbstractComponent
     }
 
     /**
-     * check the string agains RFC3986 rules
+     * Check the string against RFC3986 rules
      *
      * @param string $data
      *

--- a/src/Interfaces/Url.php
+++ b/src/Interfaces/Url.php
@@ -51,7 +51,7 @@ interface Url extends UriInterface
 
     /**
      * Returns whether two UriInterface represents the same value
-     * The Comparaison is based on the __toString method.
+     * The comparison is based on the __toString method.
      * No normalization is done
      *
      * @param UriInterface $url
@@ -110,7 +110,7 @@ interface Url extends UriInterface
      * Return an URL without the specified query offsets
      *
      * This method MUST retain the state of the current instance, and return
-     * an instance without the specidied query data
+     * an instance without the specified query data
      *
      * @param callable|array $offsets the list of offsets to remove from the query
      *                                if a callable is given it should filter the list
@@ -187,7 +187,7 @@ interface Url extends UriInterface
     public function withoutSegments($offsets);
 
     /**
-     * Return an URL without dot segments accordinf to RFC3986 algorithm
+     * Return an URL without dot segments according to RFC3986 algorithm
      *
      * This method MUST retain the state of the current instance, and return
      * an instance without dot segment according to RFC3986 algorithm

--- a/src/Interfaces/UrlPart.php
+++ b/src/Interfaces/UrlPart.php
@@ -49,7 +49,7 @@ interface UrlPart
 
     /**
      * Returns whether two URL part represent the same value
-     * The Comparaison is based on the getUriComponent method
+     * The comparison is based on the getUriComponent method
      *
      * @param UrlPart $component
      *

--- a/src/Services/SchemeRegistry.php
+++ b/src/Services/SchemeRegistry.php
@@ -48,7 +48,7 @@ class SchemeRegistry implements Interfaces\SchemeRegistry
     ];
 
     /**
-     * Registred scheme
+     * Registered scheme
      *
      * @var array
      */


### PR DESCRIPTION
This PR

* [x] fixes a few spelling errors in comments