### PR TITLE
[3.x] Fix multibyte encoding

### DIFF
--- a/src/Components/Query.php
+++ b/src/Components/Query.php
@@ -58,8 +58,8 @@ class Query extends AbstractArray implements QueryInterface, ArrayAccess
         }
 
         return str_replace(
-            array('%E7', '+'),
-            array('~', '%20'),
+            array('+'),
+            array('%20'),
             http_build_query($this->data, '', '&')
         );
     }

--- a/tests/Components/QueryTest.php
+++ b/tests/Components/QueryTest.php
@@ -159,4 +159,10 @@ class QueryTest extends PHPUnit_Framework_TestCase
         $this->assertSame('2', $query['foo']);
         $this->assertSame('', $query['bar']);
     }
+
+    public function testMultibyte()
+    {
+        $query = new Query('?query=移設');
+        $this->assertSame('query=%E7%A7%BB%E8%A8%AD', (string) $query);
+    }
 }


### PR DESCRIPTION
`移設` gets converted to `~%A7%BB%E8%A8%AD`, but should be `%E7%A7%BB%E8%A8%AD`