### PR TITLE
Fix warning for PHP < 5.6

### DIFF
--- a/src/Components/Path.php
+++ b/src/Components/Path.php
@@ -72,10 +72,15 @@ class Path extends AbstractSegment implements PathInterface
         }
         //deduce the number of similar segment according to the reference path
         $nb_common_segment = count($ref_path) - $index;
+        if ($nb_common_segment) {
+            $nb_segments = array_fill(0, $nb_common_segment, '..');
+        } else {
+            $nb_segments = array();
+        }
 
         //let's output the relative path using a new Path object
         $res = new Path(array_merge(
-            array_fill(0, $nb_common_segment, '..'),
+            $nb_segments,
             array_slice($this_path, $index),
             array($filename)
         ));

--- a/tests/Components/PathTest.php
+++ b/tests/Components/PathTest.php
@@ -121,6 +121,13 @@ class PathTest extends PHPUnit_Framework_TestCase
         $this->assertSame('../../../', $path->getRelativePath($other));
     }
 
+    public function testGetRelativePathDiffLonger()
+    {
+        $shorter = new Path('/toto/le');
+        $longer = new Path('/toto/le/heros/masson');
+        $this->assertSame('heros/masson', $longer->getRelativePath($shorter));
+    }
+
     public function testPrepend()
     {
         $path = new Path('/toto/toto/shoky/master');


### PR DESCRIPTION
Check for `0` value before calling `array_fill` as PHP versions lower
than 5.6 will throw a warning.