### PR TITLE
Enhancement: Speed up builds on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+sudo: false
+
 php:
   - 5.5
   - 5.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ matrix:
     - php: 7.0
   fast_finish: true
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 install:
   - travis_retry composer install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ cache:
     - $HOME/.composer/cache
 
 install:
-  - travis_retry composer install
+  - travis_retry composer install --prefer-dist
 
 script:
   - phpunit --coverage-text --coverage-clover=coverage.clover


### PR DESCRIPTION
This PR

* [x] directs builds on Travis to container-based infrastructure
* [x] enables caching of dependencies installed with composer between builds
* [x] preferably installs dependencies from dist, rather than from source

### Before

https://travis-ci.org/thephpleague/url/builds/70920428:

<img width="1067" alt="screen shot 2015-07-14 at 17 15 32" src="https://cloud.githubusercontent.com/assets/605483/8685357/fb607f04-2a4b-11e5-9ba2-63e6b7f09959.png">

### After

See https://travis-ci.org/thephpleague/url/builds/70978916:

<img width="1066" alt="screen shot 2015-07-14 at 17 13 09" src="https://cloud.githubusercontent.com/assets/605483/8685299/a12c5d00-2a4b-11e5-94d4-24ac8a0f723f.png">