### PR TITLE
Fix: Remove unused imports

### DIFF
--- a/src/Scheme.php
+++ b/src/Scheme.php
@@ -10,8 +10,6 @@
  */
 namespace League\Uri;
 
-use InvalidArgumentException;
-
 /**
  * Value object representing a URL scheme component.
  *

--- a/src/Schemes/Registry.php
+++ b/src/Schemes/Registry.php
@@ -14,7 +14,6 @@ use ArrayIterator;
 use InvalidArgumentException;
 use League\Uri;
 use League\Uri\Interfaces;
-use Traversable;
 
 /**
  * A class to manage schemes registry


### PR DESCRIPTION
This PR

* [x] removes unused imports (which my favorite IDE™ complained about)