### PR TITLE
Fix: Undefined classes

### DIFF
--- a/src/Host/Ip.php
+++ b/src/Host/Ip.php
@@ -9,6 +9,7 @@
  * @package   League.url
  */
 namespace League\Uri\Host;
+use InvalidArgumentException;
 
 /**
  * A Trait to validate a IP type Host

--- a/src/Interfaces/SchemeRegistry.php
+++ b/src/Interfaces/SchemeRegistry.php
@@ -9,6 +9,7 @@
  * @package   League.url
  */
 namespace League\Uri\Interfaces;
+use InvalidArgumentException;
 
 /**
  * Value object representing a URL Scheme registration system.

--- a/src/Schemes/Registry.php
+++ b/src/Schemes/Registry.php
@@ -57,7 +57,7 @@ class Registry implements Interfaces\SchemeRegistry
      * ?>
      * </code>
      *
-     * @param array scheme/standard port pair
+     * @param array $data scheme/standard port pair
      *
      * @throws InvalidArgumentException If the scheme or the port is invalid
      */


### PR DESCRIPTION
This PR

* [x] adds missing imports, as `InvalidArgumentException` is referred to in docblocks, however, the corresponding classes can not be found in the current namespace
* [x] updates a docblock with a previously missing parameter name