### PR TITLE
Enhancement: Set environment variable for collection code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
 language: php
 
-php:
-  - 5.5
-  - 5.6
-  - 7.0
-  - hhvm
-
 matrix:
+  include:
+    - php: 5.5
+      env: COLLECT_COVERAGE=true
+    - php: 5.6
+      env: COLLECT_COVERAGE=true
+    - php: 7.0
+    - php: hhvm
   allow_failures:
     - php: 7.0
   fast_finish: true
@@ -19,5 +20,4 @@ script:
 
 after_script:
  - wget https://scrutinizer-ci.com/ocular.phar
- - if [ "$TRAVIS_PHP_VERSION" == "5.5" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
- - if [ "$TRAVIS_PHP_VERSION" == "5.6" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
+ - if [ "$COLLECT_COVERAGE" == "true" ]; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi


### PR DESCRIPTION
This PR

* [x] uses an environment variable `COLLECT_COVERAGE` to determine whether coverage should be collected and sets it in the build matrix, rather than duplicating the actual command