### PR TITLE
Changed minimum requirement according to composer.json

### DIFF
--- a/3.0/index.md
+++ b/3.0/index.md
@@ -26,7 +26,7 @@ PHP. The goal of the library is to be powerful while remaining simple to use.
 * Simple API
 * URLs can be treated as Value Objects or as Immutable Value Objects
 * Composer ready and PSR-2 and PSR-4 compliant
-* PHP 5.3 as a minimal requirement
+* PHP 5.5 as a minimal requirement
 
 ## Questions?
 


### PR DESCRIPTION
The composer.json mentions a minimum php version of 5.5, while PHP 5.3 is the minimal requirement according to the documentation. 