### PR TITLE
Warn users that this package is EOL at installation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ You need **PHP >= 5.3.0** and the `mbstring` extension to use the library, but t
 Install
 -------
 
-Install `Url` using Composer.
+League\Url 3 is **End of Life** since 2015-09-23, [the new version](https://github.com/thephpleague/uri) is available at https://github.com/thephpleague/uri. If you insist on installing this old package, use:
+
 
 ```
 composer require league/url


### PR DESCRIPTION
When I was setting up a new project, I had to use URL manipulation. From another project I knew there was this awesome URL package from the thephpleague. So I googled and found this right away. Since I knew this package was good, I installed it immediately and got it working.

Then I ran `composer update` a week later, and it told me that this package was EOL. 

So this PR makes sure that other won't make the same silly mistake I made 🙈 ;)